### PR TITLE
ci: support signed commits in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -55,6 +55,9 @@
         }
     },
     "features": {
+        "ghcr.io/devcontainers-extra/features/apt-packages": {
+            "packages": ["gnupg2"]
+        },
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/devcontainers/features/node:1": {
             "version": "lts"


### PR DESCRIPTION
Add gpg to the devcontainer in order to support signed commits. See the guide on sharing [GPG keys with the devcontainer](https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials#_sharing-gpg-keys) for details.

For me the following scenario works:

**On the host machine (WSL/Ubuntu):**

- Install `gnupg2`
- Generate a GPG key and register it in GitHub
- Configure git as follows:
  ```shell
  git config --global commit.gpgsign true
  git config --global user.signingkey <your key id>
  ```

**In the devcontainer:**

- Ensure `gnupg2` is installed via the feature added in this PR
- Rebuild the container